### PR TITLE
Dates support

### DIFF
--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from datetime import date
+from dateutil.relativedelta import relativedelta
 
 from six.moves import reduce
 import logging
@@ -113,7 +114,7 @@ def get_var(data, var_name, not_found=None):
         return data
 
 
-def get_date(data, date_str, *args):
+def get_date(date_str, *args):
     return date.fromisoformat(date_str)
 
 
@@ -174,6 +175,8 @@ operations = {
     "merge": merge,
     "count": lambda *args: sum(1 if a else 0 for a in args),
     "today": lambda *args: date.today(),
+    "date": get_date,
+    "years": lambda year: relativedelta(years=year)
 }
 
 
@@ -198,8 +201,6 @@ def jsonLogic(tests, data=None):
 
     if operator == 'var':
         return get_var(data, *values)
-    if operator == 'date':
-        return get_date(data, *values)
     if operator == 'missing':
         return missing(data, *values)
     if operator == 'missing_some':

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -2,7 +2,8 @@
 # https://github.com/jwadhams/json-logic-js
 from __future__ import unicode_literals
 
-import sys
+from datetime import date, timedelta
+
 from six.moves import reduce
 import logging
 
@@ -112,6 +113,10 @@ def get_var(data, var_name, not_found=None):
         return data
 
 
+def get_date(data, date_str, *args):
+    return date.fromisoformat(date_str)
+
+
 def missing(data, *args):
     """Implements the missing operator for finding missing variables."""
     not_found = object()
@@ -192,6 +197,8 @@ def jsonLogic(tests, data=None):
 
     if operator == 'var':
         return get_var(data, *values)
+    if operator == 'date':
+        return get_date(data, *values)
     if operator == 'missing':
         return missing(data, *values)
     if operator == 'missing_some':

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -77,8 +77,19 @@ def to_numeric(arg):
             return int(arg)
     return arg
 
+
+def sum_dates(*args):
+    # Since sum() converts to ints or floats, in the case of dates the normal + operator is needed
+    total = to_numeric(args[0])
+    for arg in args[1:]:
+        total += to_numeric(arg)
+    return total
+
+
 def plus(*args):
     """Sum converts either to ints or to floats."""
+    if any([isinstance(arg, date) for arg in args]):
+        return sum_dates(*args)
     return sum(to_numeric(arg) for arg in args)
 
 

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -2,7 +2,7 @@
 # https://github.com/jwadhams/json-logic-js
 from __future__ import unicode_literals
 
-from datetime import date, timedelta
+from datetime import date
 
 from six.moves import reduce
 import logging
@@ -173,6 +173,7 @@ operations = {
     "max": lambda *args: max(args),
     "merge": merge,
     "count": lambda *args: sum(1 if a else 0 for a in args),
+    "today": lambda *args: date.today(),
 }
 
 

--- a/tests.py
+++ b/tests.py
@@ -4,6 +4,7 @@ Tests for jsonLogic.
 from __future__ import unicode_literals
 
 from datetime import date, timedelta
+from freezegun import freeze_time
 import json
 import unittest
 try:
@@ -106,8 +107,12 @@ class JSONLogicTest(unittest.TestCase):
             jsonLogic({"-": [{"date": "2021-01-01"}, {"date": "2020-01-01"}]})
         )
 
+    def test_today(self):
+        test_date = date(2021, 10, 1)
 
-
+        with freeze_time("2021-10-01"):
+            self.assertEqual(test_date, jsonLogic({"today": []}))
+            self.assertTrue(jsonLogic({"==": [{"today": []}, {"date": "2021-10-01"}]}))
 
     def test_missing(self):
         """

--- a/tests.py
+++ b/tests.py
@@ -120,6 +120,12 @@ class JSONLogicTest(unittest.TestCase):
             jsonLogic({"-": [{"date": "2021-01-01"}, {"years": 18}]})
         )
 
+    def test_sum_years_from_dates(self):
+        self.assertEqual(
+            date(2021, 1, 1),
+            jsonLogic({"+": [{"date": "2003-01-01"}, {"years": 18}]})
+        )
+
     def test_missing(self):
         """
         Takes an array of data keys to search for (same format as var).

--- a/tests.py
+++ b/tests.py
@@ -114,6 +114,12 @@ class JSONLogicTest(unittest.TestCase):
             self.assertEqual(test_date, jsonLogic({"today": []}))
             self.assertTrue(jsonLogic({"==": [{"today": []}, {"date": "2021-10-01"}]}))
 
+    def test_subtract_years_from_dates(self):
+        self.assertEqual(
+            date(2003, 1, 1),
+            jsonLogic({"-": [{"date": "2021-01-01"}, {"years": 18}]})
+        )
+
     def test_missing(self):
         """
         Takes an array of data keys to search for (same format as var).

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,7 @@ Tests for jsonLogic.
 """
 from __future__ import unicode_literals
 
+from datetime import date, timedelta
 import json
 import unittest
 try:
@@ -89,6 +90,24 @@ class JSONLogicTest(unittest.TestCase):
                 {"temp": 100, "pie": {"filling": "apple"}}
             )
         )
+
+    def test_date(self):
+        test_date = date(2021, 10, 1)
+
+        self.assertEqual(test_date, jsonLogic({"date": "2021-10-01"}))
+        self.assertEqual(test_date, jsonLogic(
+            {"date": {"var": "testDate"}},
+            {"testDate": "2021-10-01"}
+        ))
+        self.assertTrue(jsonLogic({"<=": [{"date": "2020-01-01"}, {"date": "2021-01-01"}]}))
+
+        self.assertEqual(
+            timedelta(days=366),
+            jsonLogic({"-": [{"date": "2021-01-01"}, {"date": "2020-01-01"}]})
+        )
+
+
+
 
     def test_missing(self):
         """


### PR DESCRIPTION
**Changes**
- Followed https://github.com/jwadhams/json-logic-js/issues/6#issue-182566388 to add date support.
- Added operator `{"today": []}` which returns the current date.
- Support adding/subtracting a certain number of years to a date using `relativedelta` from `dateutils`.
