### PR TITLE
Revert date operator changes

### DIFF
--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -85,7 +85,7 @@ def sum_dates(*args):
     total = args[0]
     for arg in args[1:]:
         total += arg
-    return total.isoformat()
+    return total
 
 
 def plus(*args):
@@ -102,10 +102,7 @@ def minus(*args):
     result = to_numeric(args[0]) - to_numeric(args[1])
     if isinstance(result, timedelta):
         return isodate.duration_isoformat(result)
-    elif isinstance(result, (date, datetime)):
-        return result.isoformat()
-    else:
-        return result
+    return result
 
 
 def merge(*args):

--- a/tests/test_jsonlogic.py
+++ b/tests/test_jsonlogic.py
@@ -125,34 +125,34 @@ class JSONLogicTest(unittest.TestCase):
 
     def test_relative_delta_dates(self):
         self.assertEqual(
-            "2003-01-01",
+            date(2003, 1, 1),
             jsonLogic({"-": [{"date": "2021-05-05"}, {"rdelta": [18, 4, 4]}]}),
         )
         self.assertEqual(
-            "2003-01-01",
+            date(2003, 1, 1),
             jsonLogic({"-": [{"date": "2021-05-01"}, {"rdelta": [18, 4]}]}),
         )
         self.assertEqual(
-            "2003-01-01",
+            date(2003, 1, 1),
             jsonLogic({"-": [{"date": "2021-01-01"}, {"rdelta": [18]}]}),
         )
 
         self.assertEqual(
-            "2021-05-05",
+            date(2021, 5, 5),
             jsonLogic({"+": [{"date": "2003-01-01"}, {"rdelta": [18, 4, 4]}]}),
         )
         self.assertEqual(
-            "2021-05-05",
+            date(2021, 5, 5),
             jsonLogic({"+": [{"date": "2003-01-05"}, {"rdelta": [18, 4]}]}),
         )
         self.assertEqual(
-            "2021-05-05",
+            date(2021, 5, 5),
             jsonLogic({"+": [{"date": "2003-05-05"}, {"rdelta": [18]}]}),
         )
 
     def test_relative_delta_datetimes(self):
         self.assertEqual(
-            "2023-12-02T11:01:01+01:00",
+            datetime(2023, 12, 2, 11, 1, 1, tzinfo=timezone(timedelta(seconds=3600))),
             jsonLogic(
                 {
                     "+": [
@@ -163,7 +163,7 @@ class JSONLogicTest(unittest.TestCase):
             ),
         )
         self.assertEqual(
-            "2023-12-02T10:00:00+01:00",
+            datetime(2023, 12, 2, 10, 0, 0, tzinfo=timezone(timedelta(seconds=3600))),
             jsonLogic(
                 {
                     "+": [
@@ -174,7 +174,7 @@ class JSONLogicTest(unittest.TestCase):
             ),
         )
         self.assertEqual(
-            "2022-11-01T11:01:01+01:00",
+            datetime(2022, 11, 1, 11, 1, 1, tzinfo=timezone(timedelta(seconds=3600))),
             jsonLogic(
                 {
                     "+": [
@@ -519,11 +519,11 @@ class JSONLogicTest(unittest.TestCase):
 
         rule = {"+": [{"date": {"var": "date1"}}, {"duration": {"var": "period"}}]}
 
-        self.assertEqual("2023-01-02", jsonLogic(rule, data))
+        self.assertEqual(date(2023, 1, 2), jsonLogic(rule, data))
 
         rule = {"+": [{"date": "2023-02-01"}, {"duration": "P1M"}]}
 
-        self.assertEqual("2023-03-01", jsonLogic(rule, {}))
+        self.assertEqual(date(2023, 3, 1), jsonLogic(rule, {}))
 
     def test_add_durations_to_datetimes(self):
         data = {"datetime1": "2023-01-01T10:00:00+01:00", "period": "P1M1DT1H5M"}
@@ -532,7 +532,10 @@ class JSONLogicTest(unittest.TestCase):
             "+": [{"datetime": {"var": "datetime1"}}, {"duration": {"var": "period"}}]
         }
 
-        self.assertEqual("2023-02-02T11:05:00+01:00", jsonLogic(rule, data))
+        self.assertEqual(
+            datetime(2023, 2, 2, 11, 5, 0, tzinfo=timezone(timedelta(seconds=3600))),
+            jsonLogic(rule, data),
+        )
 
     def test_comparing_periods(self):
         data = {"date1": "2023-01-01", "date2": "2023-02-01"}


### PR DESCRIPTION
Part of https://github.com/open-formulieren/open-forms/issues/2953

I decided to revert back the change because:
- It doesn't make the rules completely consistent: static variables in the logic rules are already python types, so the "date"/"datetime" operators are not needed.
- The data migration to convert existing rules would have been quite complex and error prone, since it needed to find all rules where a "rdelta" operator was used and wrap the expression into either a "date" or "datetime" operator (which was not easy to determine)