### PR TITLE
Extend duration function to allow retrieving the unit

### DIFF
--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -65,10 +65,13 @@ def get_duration(duration, unit=None):
     """
     Gets the duration of a string. It is possible to get the duration in a different unit by specifying unit.
     """
-    duration = isodate.parse_duration(duration)
+    if not duration:
+        return duration
 
     if not unit:
         return duration
+
+    duration = isodate.parse_duration(duration)
 
     match unit:
         case "days":


### PR DESCRIPTION
Closes #20 

This change extends the duration function in order to allow retrieving the unit. You can use this as follows:

```
{"duration": [{"-": [{"date": "2025-02-10"}, {"date": "1978-01-01"}]}, "days"]}
```

This returns:

```
17207
```

This can be used for example to calculate the day of the week for a given date:

```
{"%": [{"duration": [{"-": [{"date": "2025-02-10"}, {"date": "1978-01-01"}]}, "days"]}, 7]}
```

This returns:

```
1
```

In this calculation this represents Monday. This is because 1978-01-01 is a Sunday (0).

Curious to hear if you like this solution direction.