### PR TITLE
Update CI for publishing on PyPI and Python to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        python: ['3.10']
+        python: ['3.12']
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -36,14 +36,17 @@ jobs:
     name: Publish package to PyPI
     runs-on: ubuntu-latest
     needs: tests
+    environment: release
+    permissions:
+      id-token: write
 
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Build sdist and wheel
         run: |
@@ -51,7 +54,4 @@ jobs:
           python setup.py sdist bdist_wheel
 
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         toxenv: [isort, black, flake8]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install dependencies
         run: pip install tox
       - run: tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,7 @@ classifiers =
     Operating System :: Unix
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
 envlist =
     clean
-    py310
+    py312
     isort
     black
     flake8
 
 [gh-actions]
 python =
-    3.10: py310
-    3.11: py311
+    3.12: py312
 
 [testenv]
 extras =


### PR DESCRIPTION
I also did an attempt at switching to pyproject.toml instead, but apparently flake8 cannot be configured via it :(